### PR TITLE
Turns off the no-console eslint rule.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,7 @@
             "error",
             "always"
         ],
-        "no-console": 1,
+        "no-console": 0,
         "no-unused-vars": 1
     }
 }


### PR DESCRIPTION
Relaxes the no-console rule since we don't use a proper logging framework and heroku captures and logs stdout anyway.